### PR TITLE
Handle edge cases

### DIFF
--- a/R/annoPeaks.R
+++ b/R/annoPeaks.R
@@ -75,7 +75,17 @@ annoPeaks <- function(peaks, annoData,
     }
     stopifnot(inherits(peaks, "GRanges"))
     stopifnot(inherits(annoData, c("annoGR", "GRanges")))
-    stopifnot(length(intersect(seqlevelsStyle(peaks),seqlevelsStyle(annoData)))>0)
+    check_seqlevel <- tryCatch({
+    	seqlevelsStyle(peaks)
+    	seqlevelsStyle(annoData)
+    }, error = function(w) {
+    	message("Warning: seqlevel style not recognized, you are probably using custom GRange objects: ", w$message)
+    	return(NA)
+    })
+    if (!is.na(check_seqlevel)) {
+    	stopifnot(length(intersect(seqlevelsStyle(peaks),seqlevelsStyle(annoData)))>0)
+    }
+    # stopifnot(length(intersect(seqlevelsStyle(peaks),seqlevelsStyle(annoData)))>0)
     stopifnot(length(bindingRegion)==2)
     stopifnot(bindingRegion[1]<=0 && bindingRegion[2]>=1)
     if(ignore.peak.strand){

--- a/R/getEnrichedGO.R
+++ b/R/getEnrichedGO.R
@@ -249,12 +249,21 @@ getEnrichedGO <- function(annotatedPeak, orgAnn,
     xx <- mget(mapped_genes, goAnn, ifnotfound=NA)
     all.GO <- cbind(matrix(unlist(unlist(xx)),ncol=3,byrow=TRUE),
                     rep(names(xx), elementNROWS(xx)))
-    all.GO <- unique(all.GO)## incalse the database is not unique
+    all.GO <- unique(all.GO)## in case the database is not unique
+    if (!(inherits(all.GO, "matrix"))) {
+      all.GO <- matrix(all.GO, nrow = 1)
+    }
     this.GO <- all.GO[all.GO[, 4] %in% entrezIDs, , drop=FALSE]
+    if (!(inherits(this.GO, "matrix"))) {
+      this.GO <- matrix(this.GO, nrow = 1)
+    }
     FALSE.GO <- all.GO[all.GO[, 4] %in% entrezIDs_FALSE, , drop=FALSE]
 
     addAnc <- function(go.ids,
                        onto=c("bp", "cc", "mf")){
+    		if (!(inherits(go.ids, "matrix"))) {
+    			go.ids <- matrix(go.ids, nrow = 1)
+    		}
         ##replace the function addAncestors
         GOIDs <- unique(as.character(go.ids[, 1]))
         empty <- matrix(nrow=0, ncol=2)
@@ -309,9 +318,9 @@ getEnrichedGO <- function(annotatedPeak, orgAnn,
         re
     }
 
-    bp.go.this.withEntrez = addAnc(this.GO[this.GO[,3]=="BP",],"bp")
+    bp.go.this.withEntrez = addAnc(this.GO[this.GO[,3]=="BP",], "bp")
     cc.go.this.withEntrez = addAnc(this.GO[this.GO[,3]=="CC",], "cc")
-    mf.go.this.withEntrez = addAnc(this.GO[this.GO[,3]=="MF",],"mf")
+    mf.go.this.withEntrez = addAnc(this.GO[this.GO[,3]=="MF",], "mf")
 
     bp.go.all.withEntrez  = addAnc(all.GO[all.GO[,3]=="BP",], "bp")
     cc.go.all.withEntrez = addAnc(all.GO[all.GO[,3]=="CC",], "cc")

--- a/R/getEnrichedPATH.R
+++ b/R/getEnrichedPATH.R
@@ -207,12 +207,14 @@ Entrez Gene to pathway identifies named as xxxxxEXTID2PATHID
         }
     }))
 
-    all.PATH <- unique(all.PATH)## incase the database is not unique
-    this.PATH <- unique(this.PATH)
 
+    all.PATH <- unique(all.PATH)## in case the database is not unique
+    this.PATH <- unique(this.PATH)
+    if (is.null(all.PATH) | is.null(this.PATH)) {
+    	return("No enriched pathway found!")
+    }
     colnames(all.PATH)<-c("path.id","entrez_id")
     colnames(this.PATH)<-c("path.id","entrez_id")
-
     path.all<-as.character(all.PATH[,"path.id"])
     path.this<-as.character(this.PATH[,"path.id"])
 
@@ -246,7 +248,7 @@ Entrez Gene to pathway identifies named as xxxxxEXTID2PATHID
 
     colnames(selected) = c("path.id", "count.InDataset", "count.InGenome",
                            "pvalue", "totaltermInDataset", "totaltermInGenome")
-
+		
     annoTerms <- function(termids){
         if(length(termids)<1){
             goterm <- matrix(ncol=2)

--- a/R/getEnrichedPATH.R
+++ b/R/getEnrichedPATH.R
@@ -211,7 +211,7 @@ Entrez Gene to pathway identifies named as xxxxxEXTID2PATHID
     all.PATH <- unique(all.PATH)## in case the database is not unique
     this.PATH <- unique(this.PATH)
     if (is.null(all.PATH) | is.null(this.PATH)) {
-    	return("No enriched pathway found!")
+    	return(data.frame(log = "No enriched pathway found!"))
     }
     colnames(all.PATH)<-c("path.id","entrez_id")
     colnames(this.PATH)<-c("path.id","entrez_id")


### PR DESCRIPTION
Minor changes to better handle edge case where detected GO or PATHWAY are zero.
For example, below code assumes `all.GO` is a matrix, but when there is only one GO detected, `all.GO` becomes a vector and the `all.GO[,4]` syntax is no longer valid.
```
this.GO <- all.GO[all.GO[, 4] %in% entrezIDs, , drop=FALSE]
```