### PR TITLE
minor fixes for 3.36.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: Batch annotation of the peaks identified from either ChIP-seq,
     ChIP-chip experiments or any experiments resulted in large
     number of chromosome ranges
-Version: 3.36.0
+Version: 3.36.1
 Encoding: UTF-8
 Author: Lihua Julie Zhu, Jianhong Ou, Jun Yu, Kai Hu, Haibo Liu, 
     Hervé Pagès, Claude Gazin,

--- a/R/annoGR.R
+++ b/R/annoGR.R
@@ -143,12 +143,8 @@ newAGR <- function(gr, ...){
               ...)
 }
 
-if(!isGeneric("annoGR")){
-    setGeneric("annoGR", function(ranges, ...) standardGeneric("annoGR"))
-}
-if(!isGeneric("info")){
-    setGeneric("info", function(object) standardGeneric("info"))
-}
+setGeneric("annoGR", function(ranges, ...) standardGeneric("annoGR"))
+setGeneric("info", function(object) standardGeneric("info"))
 
 #' @name coerce
 #' @import GenomicRanges

--- a/R/findEnhancers.R
+++ b/R/findEnhancers.R
@@ -59,6 +59,9 @@
 #'   library(EnsDb.Hsapiens.v75)
 #'   annoData <- toGRanges(EnsDb.Hsapiens.v75, feature="gene")
 #'   data("myPeakList")
+#'   seqlevelsStyle(myPeakList) <- "Ensembl"
+#'   seqlevelsStyle(annoData) <- "Ensembl"
+#'   seqlevelsStyle(DNAinteractiveData) <- "Ensembl"
 #'   findEnhancers(myPeakList[500:1000], annoData, DNAinteractiveData)
 #'   
 findEnhancers <- function(peaks, annoData, DNAinteractiveData, 

--- a/man/findEnhancers.Rd
+++ b/man/findEnhancers.Rd
@@ -72,6 +72,9 @@ techniques such as 3C, 5C or HiC.
   library(EnsDb.Hsapiens.v75)
   annoData <- toGRanges(EnsDb.Hsapiens.v75, feature="gene")
   data("myPeakList")
+  seqlevelsStyle(myPeakList) <- "Ensembl"
+  seqlevelsStyle(annoData) <- "Ensembl"
+  seqlevelsStyle(DNAinteractiveData) <- "Ensembl"
   findEnhancers(myPeakList[500:1000], annoData, DNAinteractiveData)
   
 }

--- a/tests/testthat/test_getAllPeakSequence.R
+++ b/tests/testthat/test_getAllPeakSequence.R
@@ -4,6 +4,7 @@ test_that("getAllPeakSequence works not correct", {
                      IRanges(start=c(10,300,60348387, 60348490),
                              end=c(50,330,60348389, 60348498), 
                              names=c("p1","p2","p0", "p3")))
+    seqlevelsStyle(peaks) <- "UCSC"
     suppressWarnings(seq <- 
                          getAllPeakSequence(peaks, 
                                             upstream = 20, 

--- a/vignettes/pipeline.Rmd
+++ b/vignettes/pipeline.Rmd
@@ -151,6 +151,7 @@ to annotate the peaks to the promoter regions of Hg19 genes.
 Promoters can be specified with bindingRegion. For the following example, promoter region is defined as upstream 2000 and downstream 500 from TSS (bindingRegion=c(-2000, 500)).
 
 ```{r workflow3}
+seqlevelsStyle(overlaps) <- seqlevelsStyle(annoData) <- "Ensembl"
 overlaps.anno <- annotatePeakInBatch(overlaps, 
                                      AnnotationData=annoData, 
                                      output="nearestBiDirectionalPromoters",
@@ -261,6 +262,7 @@ DNA5C <- system.file("extdata",
                      "wgEncodeUmassDekker5CGm12878PkV2.bed.gz",
                      package="ChIPpeakAnno")
 DNAinteractiveData <- toGRanges(gzfile(DNA5C))
+seqlevelsStyle(overlaps) <- seqlevelsStyle(annoData) <- seqlevelsStyle(DNAinteractiveData) <- "Ensembl"
 findEnhancers(overlaps, annoData, DNAinteractiveData)
 ```
 

--- a/vignettes/quickStart.Rmd
+++ b/vignettes/quickStart.Rmd
@@ -62,8 +62,8 @@ annoData[1:2]
 ```
 ## Step 3: Annotate the peaks with `annotatePeakInBatch`
 ```{r annotate}
-## keep the seqnames in the same style
-seqlevelsStyle(peaks) <- seqlevelsStyle(annoData)
+## keep the seqnames in the same style if needed
+seqlevelsStyle(peaks) <- seqlevelsStyle(annoData) <- "Ensembl"
 ## do annotation by nearest TSS
 anno <- annotatePeakInBatch(peaks, AnnotationData=annoData)
 anno[1:2]


### PR DESCRIPTION
Fix the "R CMD check" failed issues:
1. Caused by `seqlevelsStyle()` function not fully ready in BioC 3.18, check: (https://support.bioconductor.org/p/9156488/). This will not be a concern for the ChIPpeakAnno dev version since `seqlevelsStyle()` will be patched soon.
2. Fixed another minor bug that is already patched in the dev version for `annoGR.R`.
3. Bumped version to 3.36.1 and rerun `roxygenize()` to update the documentations.