### PR TITLE
minor fix to resolve the seqlevelsStyle() issue

### DIFF
--- a/R/findEnhancers.R
+++ b/R/findEnhancers.R
@@ -59,9 +59,7 @@
 #'   library(EnsDb.Hsapiens.v75)
 #'   annoData <- toGRanges(EnsDb.Hsapiens.v75, feature="gene")
 #'   data("myPeakList")
-#'   seqlevelsStyle(myPeakList) <- "Ensembl"
-#'   seqlevelsStyle(annoData) <- "Ensembl"
-#'   seqlevelsStyle(DNAinteractiveData) <- "Ensembl"
+#'   seqlevelsStyle(myPeakList) <- seqlevelsStyle(annoData) <- seqlevelsStyle(DNAinteractiveData)
 #'   findEnhancers(myPeakList[500:1000], annoData, DNAinteractiveData)
 #'   
 findEnhancers <- function(peaks, annoData, DNAinteractiveData, 

--- a/man/findEnhancers.Rd
+++ b/man/findEnhancers.Rd
@@ -72,9 +72,7 @@ techniques such as 3C, 5C or HiC.
   library(EnsDb.Hsapiens.v75)
   annoData <- toGRanges(EnsDb.Hsapiens.v75, feature="gene")
   data("myPeakList")
-  seqlevelsStyle(myPeakList) <- "Ensembl"
-  seqlevelsStyle(annoData) <- "Ensembl"
-  seqlevelsStyle(DNAinteractiveData) <- "Ensembl"
+  seqlevelsStyle(myPeakList) <- seqlevelsStyle(annoData) <- seqlevelsStyle(DNAinteractiveData)
   findEnhancers(myPeakList[500:1000], annoData, DNAinteractiveData)
   
 }

--- a/vignettes/pipeline.Rmd
+++ b/vignettes/pipeline.Rmd
@@ -151,7 +151,7 @@ to annotate the peaks to the promoter regions of Hg19 genes.
 Promoters can be specified with bindingRegion. For the following example, promoter region is defined as upstream 2000 and downstream 500 from TSS (bindingRegion=c(-2000, 500)).
 
 ```{r workflow3}
-seqlevelsStyle(overlaps) <- seqlevelsStyle(annoData) <- "Ensembl"
+seqlevelsStyle(overlaps) <- seqlevelsStyle(annoData)
 overlaps.anno <- annotatePeakInBatch(overlaps, 
                                      AnnotationData=annoData, 
                                      output="nearestBiDirectionalPromoters",
@@ -262,7 +262,7 @@ DNA5C <- system.file("extdata",
                      "wgEncodeUmassDekker5CGm12878PkV2.bed.gz",
                      package="ChIPpeakAnno")
 DNAinteractiveData <- toGRanges(gzfile(DNA5C))
-seqlevelsStyle(overlaps) <- seqlevelsStyle(annoData) <- seqlevelsStyle(DNAinteractiveData) <- "Ensembl"
+seqlevelsStyle(overlaps) <- seqlevelsStyle(annoData) <- seqlevelsStyle(DNAinteractiveData)
 findEnhancers(overlaps, annoData, DNAinteractiveData)
 ```
 

--- a/vignettes/quickStart.Rmd
+++ b/vignettes/quickStart.Rmd
@@ -63,7 +63,7 @@ annoData[1:2]
 ## Step 3: Annotate the peaks with `annotatePeakInBatch`
 ```{r annotate}
 ## keep the seqnames in the same style if needed
-seqlevelsStyle(peaks) <- seqlevelsStyle(annoData) <- "Ensembl"
+seqlevelsStyle(peaks) <- seqlevelsStyle(annoData)
 ## do annotation by nearest TSS
 anno <- annotatePeakInBatch(peaks, AnnotationData=annoData)
 anno[1:2]


### PR DESCRIPTION
Hi Jianhong,

Seems that "Ensembl" is no longer a valid option for `seqlevelsStyle()` with the Bioc 3.18 release being pushed through. However, the previous error when setting seqlevelsStyle to "UCSC" is also gone. Therefore, I reverted the relevant codes and the package builds well. Let me know if not,

Best,